### PR TITLE
Simplify Support channel plugin and add reset message cache command to telegram

### DIFF
--- a/Ai.Orchestrator.Plugins.SupportChannelKb/Models/ServiceConfig.cs
+++ b/Ai.Orchestrator.Plugins.SupportChannelKb/Models/ServiceConfig.cs
@@ -9,5 +9,6 @@ public record ServiceConfig: IPluginConfig
     public string Description { get; set; }
     public IEnumerable<ToolCall> Tools { get; set; }
     public string SupportChannelKbUrl { get; set; }
-    public IEnumerable<SupportChannel> Channels { get; set; }
+    public string DefaultSaveChannel { get; set; }
+    public string DefaultChannelApiKey { get; set; }
 }

--- a/Ai.Orchestrator.Plugins.SupportChannelKb/Models/ServiceRequest.cs
+++ b/Ai.Orchestrator.Plugins.SupportChannelKb/Models/ServiceRequest.cs
@@ -10,7 +10,6 @@ public record ServiceRequest: IPluginServiceRequest
     
     public string SearchCriteria { get; set; }
     public string SupportChannel { get; set; }
-    public string ApiKey { get; set; }
     public string Description { get; set; }
     public string NewInformation { get; set; }
     public List<Dictionary<string, string>> NewInformationMetaData { get; set; } = new();

--- a/Ai.Orchestrator.Plugins.SupportChannelKb/SupportChannelKbService.cs
+++ b/Ai.Orchestrator.Plugins.SupportChannelKb/SupportChannelKbService.cs
@@ -15,18 +15,17 @@ public class SupportChannelKbService
 
     public async Task<string[]> SearchKnowledgeBase(ServiceRequest request)
     {
-        FilterOutDumbAiApiPlaceholders(request);
         using var httpClient = new HttpClient();
         
         httpClient.DefaultRequestHeaders.Authorization = 
-            new AuthenticationHeaderValue("Bearer", request.ApiKey);
+            new AuthenticationHeaderValue("Bearer", _config.DefaultChannelApiKey);
         httpClient.DefaultRequestHeaders.Accept.Add(
             new MediaTypeWithQualityHeaderValue("application/json"));
 
         var requestBody = new { text = request.SearchCriteria };
         
         var response = await httpClient.PostAsJsonAsync(
-            $"{_config.SupportChannelKbUrl}/search/{request.SupportChannel}", 
+            $"{_config.SupportChannelKbUrl}/search/{_config.DefaultSaveChannel}", 
             requestBody
         );
 
@@ -84,7 +83,7 @@ public class SupportChannelKbService
         };
         
         var response = await httpClient.PostAsJsonAsync(
-            $"{_config.SupportChannelKbUrl}/text/{request.SupportChannel}", 
+            $"{_config.SupportChannelKbUrl}/text/{_config.DefaultSaveChannel}", 
             requestBody
         );
 
@@ -103,20 +102,5 @@ public class SupportChannelKbService
         response.EnsureSuccessStatusCode();
 
         return response.Content.ReadFromJsonAsync<dynamic>();
-    }
-
-    private void FilterOutDumbAiApiPlaceholders(ServiceRequest request)
-    {
-        if (string.IsNullOrWhiteSpace(request.ApiKey))
-        {
-            throw new Exception("API Key is missing. Get API key using get_support_channel_collections");
-        }
-
-        var requestApiKey = request.ApiKey.ToLower();
-
-        if (!Guid.TryParse(requestApiKey, out _))
-        {
-            throw new Exception("API Key is incorrect. Get API key using get_support_channel_collections");
-        }
     }
 }

--- a/Ai.Orchestrator.Plugins.Telegram/TelegramCommand.cs
+++ b/Ai.Orchestrator.Plugins.Telegram/TelegramCommand.cs
@@ -63,7 +63,13 @@ public class TelegramCommand: CommandBase<ServiceRequest, ServiceConfig>
                                 ? $"telegram-{lastMessage.Message?.Chat.Username}"
                                 : null;
                             Console.WriteLine($"Telegram bot ${lastMessage.Message?.Chat.Id} received message: '{concatenatedMessage}'");
-        
+
+                            if (await ProcessSpecialCommands(conversationId, lastMessage.Message?.Chat.Id.ToString(), conversationId, concatenatedMessage))
+                            {
+                                clientUpdates = await _client.GetUpdates(updates.Last().Id + (tryAgain ? 0 : 1));
+                                continue;
+                            }
+                            
                             var serviceRequest = new
                             {
                                 SystemPrompt = (string)null,
@@ -140,6 +146,29 @@ public class TelegramCommand: CommandBase<ServiceRequest, ServiceConfig>
 
         return Task.CompletedTask;
     }
+
+    private async Task<bool> ProcessSpecialCommands(string botToken, string chatId, string conversationId, string message)
+    {
+        if (message.StartsWith('/'))
+        {
+            string response = null;
+            switch (message.ToLower())
+            {
+                case "/reset":
+                    await MessageCache.ClearMessageCache(conversationId);
+                    response = "Message cache reset";
+                    break;
+            }
+
+            if (!string.IsNullOrWhiteSpace(response))
+            {
+                await SendMessage(botToken, chatId, response);
+            }
+            return true;
+        }
+
+        return false;
+    }
     
     private List<ChatMessageHistory> RemoveNonUserMessagesFromEnd(List<ChatMessageHistory> cachedMessages)
     {
@@ -157,8 +186,7 @@ public class TelegramCommand: CommandBase<ServiceRequest, ServiceConfig>
 
         return modifiedMessages;
     }
-
-
+    
     private async Task<object> SendMessage(string botToken, string chatId, string messageText)
     {
         if (string.IsNullOrEmpty(chatId))


### PR DESCRIPTION
- Added default channel and default channel api key
- temporarily removing api key from service request
- Remove janky AI filter
- use config api key
- use config support channel
- Add reset message cache command and support for adding other special commands to telegram command